### PR TITLE
Add GitHub Actions configuration for Java backend with Maven build an…

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -24,3 +24,23 @@ jobs:
         run: npm run build
       - name: Run tests
         run: npm run test
+  main-backend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Java 17 with Maven
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Change directory
+        run: cd ./backend
+      - name: Install dependencies
+        run: mvn install -DskipTests
+      - name: Build the project
+        run: mvn package -DskipTests
+      - name: Run tests
+        run: mvn test

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   storage-service:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: storage-service
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -16,8 +19,6 @@ jobs:
           node-version: '18'
       - name: Install Docker
         uses: docker/setup-buildx-action@v3
-      - name: Change directory
-        run: cd ./storage-service
       - name: Install dependencies
         run: npm install
       - name: Build the project
@@ -26,6 +27,9 @@ jobs:
         run: npm run test
   main-backend:
     runs-on: ubuntu-latest
+    defaults:
+        run:
+            working-directory: backend
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -36,8 +40,6 @@ jobs:
           distribution: 'temurin'
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Change directory
-        run: cd ./backend
       - name: Install dependencies
         run: mvn install -DskipTests
       - name: Build the project


### PR DESCRIPTION
This pull request includes significant updates to the CI/CD pipeline configuration in the `.github/workflows/on_pull_request.yml` file. The changes introduce a new job for the main backend, setting up Java 17, Docker Buildx, and Maven, and updating the steps to build and test the backend.

Key changes include:

### CI/CD Pipeline Enhancements:
* Added a new job `main-backend` that runs on `ubuntu-latest`.
* Configured the job to checkout code using `actions/checkout@v4`.
* Set up Java 17 with Maven using `actions/setup-java@v4` with `temurin` distribution.
* Set up Docker Buildx using `docker/setup-buildx-action@v3`.
* Added steps to change directory to `./backend`, install dependencies, build the project, and run tests using Maven.